### PR TITLE
Feat: about method adb name

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ Usage: FlakeScanner [options] appName testPackage apkPath testRunnerClsPath test
   testRunnerClsPath
   testClassPath
   testMethodPath
+  testMethodNameInAdb
+```
+
+Arguments example:
+
+```shell
+--adbPath ~/aosp-9/out/host/linux-x86/bin/adb \
+--deviceName emulator-5556 \
+de.danoeh.antennapod.debug \
+de.test.antennapod \
+~/apks/AntennaPod-debug.apk \
+androidx.test.runner.AndroidJUnitRunner \
+de.test.antennapod.playback.PlaybackTest \
+testContinousPlaybackOffSingleEpisode \
+testContinousPlaybackOffSingleEpisode[sonic] # method name in adb might not be identical to name used to locate method.
 ```
 
 Assuming you have the `aapt2` tool comes with Android SDK 29 or later.

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="ALL">
+    <ThresholdFilter level="all"/>
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d %-5p method: [%t] %C{2} (%F:%L) - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="all">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/src/main/scala/org/ftd/Master/Config.scala
+++ b/src/main/scala/org/ftd/Master/Config.scala
@@ -11,6 +11,7 @@ case class Config(
                    testRunnerClsPath: String = null,
                    testClassPath: String = null,
                    testMethodPath: String = null,
+                   testMethodNameInAdb: String = null,
                    adbPath: Path = null,
                    deviceName: String = null,
                    appName: String = null,

--- a/src/main/scala/org/ftd/Master/Main.scala
+++ b/src/main/scala/org/ftd/Master/Main.scala
@@ -130,7 +130,8 @@ object Main {
       logger.info("Package installed")
 
       val testRunner = new RemoteAndroidTestRunner(config.testPackage, config.testRunnerClsPath, device)
-      testRunner setMethodName(config.testClassPath, config.testMethodPath)
+      // set adb command
+      testRunner setMethodName(config.testClassPath, config.testMethodNameInAdb)
       testRunner setRunOptions( testRunner.getRunOptions + " --no-window-animation" )
 
       val strategy: Strategy = config.strategy match {

--- a/src/main/scala/org/ftd/Master/utils/CLI.scala
+++ b/src/main/scala/org/ftd/Master/utils/CLI.scala
@@ -97,6 +97,10 @@ object CLI {
         arg[String]("testMethodPath")
           .required()
           .action((x, c) => c.copy(testMethodPath = x))
+
+        arg[String]("testMethodNameInAdb")
+          .required()
+          .action((x, c) => c.copy(testMethodNameInAdb = x))
     }
 
     parser.parse(args, Config()) match {


### PR DESCRIPTION
FlakeScanner now cannot distinguish "test method name used in adb command" and "test method name used to locate method". 

E.g. if adb command is:

```shell
adb shell am instrument -w -r  --no-window-animation  -e debug false -e class \
de.test.antennapod.playback.PlaybackTest#testContinousPlaybackOffSingleEpisode[sonic] \
de.test.antennapod/androidx.test.runner.AndroidJUnitRunner
```

FlakeScanner tries to use `testContinousPlaybackOffSingleEpisode[sonic]` to locate method. However, the real method name is `testContinousPlaybackOffSingleEpisode`, and FlakeScanner'll report "no test found".

In this PR, I seperate two types of "method name" metioned above.

(I also add log4j2.xml in resource folder, to enable log4j as default.)